### PR TITLE
Fix typo

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -81,7 +81,7 @@ if [[ $migration_process -eq 1 ]]; then
     db_user=$app
 
     # Replace the user
-    ynh_system_user_delete $old_app
+    ynh_system_user_delete --username="$old_app"
     test getent passwd "$app" &>/dev/null || \
         useradd -d "$datadir" --system --user-group "$app" --shell /bin/bash || \
             ynh_die --message "Unable to create $app system account"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -72,7 +72,7 @@ fi
 
 [[ $YNH_APP_ID == "garradin" ]] \
     && [[ "$(cat "/opt/$app/templates/.VERSION")" != 1.2.2 ]] \
-    && ynh_die --message "It look like that you have an old Garradin install. You need first upgrade Gogs instance (id: $garradin_migrate_id) and after migrate to Paheko."
+    && ynh_die --message "It look like that you have an old Garradin install. You need first upgrade Garradin instance (id: $garradin_migrate_id) and after migrate to Paheko."
 ynh_handle_app_migration --migration_id=garradin --migration_list=garradin_migrations
 
 if [[ $migration_process -eq 1 ]]; then


### PR DESCRIPTION
## Problem

- The upgrade mentions that we should upgrade Gogs first
- The positional arguments are not documented and deprecated

## Solution

- Rename Gogs to Garradin
- Use `ynh_system_delete_user --username="USERNAME"` instead of `ynh_system_delete_user USERNAME`

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
