### PR TITLE
Comment smtp server constants from default config file

### DIFF
--- a/conf/config.local.php
+++ b/conf/config.local.php
@@ -412,7 +412,7 @@ const USE_CRON = true;
  * Défaut : false
  */
 
-const SMTP_HOST = '__DOMAIN__';
+//const SMTP_HOST = '__DOMAIN__';
 
 /**
  * Port du serveur SMTP
@@ -423,7 +423,7 @@ const SMTP_HOST = '__DOMAIN__';
  * Défaut : 587
  */
 
-const SMTP_PORT = 25;
+//const SMTP_PORT = 25;
 
 /**
  * Login utilisateur pour le server SMTP
@@ -433,7 +433,7 @@ const SMTP_PORT = 25;
  * Défaut : null
  */
 
-const SMTP_USER = '__APP__';
+//const SMTP_USER = '__APP__';
 
 /**
  * Mot de passe pour le serveur SMTP
@@ -443,7 +443,7 @@ const SMTP_USER = '__APP__';
  * Défaut : null
  */
 
-const SMTP_PASSWORD = '__MAIL_PWD__';
+//const SMTP_PASSWORD = '__MAIL_PWD__';
 
 /**
  * Sécurité du serveur SMTP
@@ -456,7 +456,7 @@ const SMTP_PASSWORD = '__MAIL_PWD__';
  * Défaut : STARTTLS
  */
 
-const SMTP_SECURITY = 'STARTTLS';
+//const SMTP_SECURITY = 'STARTTLS';
 
 /**
  * Nom du serveur utilisé dans le HELO SMTP
@@ -469,7 +469,7 @@ const SMTP_SECURITY = 'STARTTLS';
  * @var null|string
  */
 
-const SMTP_HELO_HOSTNAME = '__DOMAIN__';
+//const SMTP_HELO_HOSTNAME = '__DOMAIN__';
 
 /**
  * Adresse e-mail destinée à recevoir les erreurs de mail
@@ -485,7 +485,7 @@ const SMTP_HELO_HOSTNAME = '__DOMAIN__';
  * Défaut : null
  */
 
-const MAIL_RETURN_PATH = '__APP__@__DOMAIN__';
+//const MAIL_RETURN_PATH = '__APP__@__DOMAIN__';
 
 
 /**
@@ -503,7 +503,7 @@ const MAIL_RETURN_PATH = '__APP__@__DOMAIN__';
  * Défaut : null
  */
 
-const MAIL_SENDER = '__APP__@__DOMAIN__';
+//const MAIL_SENDER = '__APP__@__DOMAIN__';
 
 /**
  * Mot de passe pour l'accès à l'API permettant de gérer les mails d'erreur


### PR DESCRIPTION
## Problem

Le fichier `config.local.php` a des constantes non commentées, ce qui empêche de les modifier dans `config.local.user.php`. N'étant pas vraiment familier du PHP, peut-être je suis passé à côté d'une manière de les modifier...

## Solution

La PR propose de commenter toutes les constantes liées à l'envoi de mails dans le fichier `config.local.php`