### PR TITLE
Fix PHP version used by cron

### DIFF
--- a/conf/cron
+++ b/conf/cron
@@ -1,4 +1,4 @@
-@daily __APP__ [ -f __DATA_DIR__/data/association.sqlite ] && __INSTALL_DIR__/bin/paheko cron
-* * * * * __APP__ [ -f __DATA_DIR__/data/association.sqlite ] && __INSTALL_DIR__/bin/paheko queue run --quiet
+@daily __APP__ [ -f __DATA_DIR__/data/association.sqlite ] && /usr/bin/php__PHPVERSION__ -f __INSTALL_DIR__/bin/paheko cron
+* * * * * __APP__ [ -f __DATA_DIR__/data/association.sqlite ] && /usr/bin/php__PHPVERSION__ -f __INSTALL_DIR__/bin/paheko queue run --quiet
 
 # the '-f' command is a workaround for a bug in the 1.3.12 release, so should be fixed in a future release


### PR DESCRIPTION
## Problem

- [Cron fails](https://forum.yunohost.org/t/probleme-avec-cron-et-paheko/31551) with

```
Le module de base de données SQLite3 n'est pas disponible.
```

## Solution

- Explicitly specify PHP version to use, a'la [nextcloud's cron](https://github.com/YunoHost-Apps/nextcloud_ynh/blob/master/conf/nextcloud.cron)

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
