### PR TITLE
Add php8.3-gd dep

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -91,5 +91,5 @@ ram.runtime = "200M"
     webdav.auth_header = false
 
     [resources.apt]
-    packages = "sqlite3, php8.3-sqlite3, php8.3-imagick, php8.3-intl, php8.3-cli, php8.3-gnupg, php8.3-mbstring, php8.3-zip, php8.3-xml, mupdf-tools, ffmpeg, gnumeric"
+    packages = "sqlite3, php8.3-sqlite3, php8.3-imagick, php8.3-intl, php8.3-cli, php8.3-gnupg, php8.3-mbstring, php8.3-zip, php8.3-xml, mupdf-tools, ffmpeg, gnumeric, php8.3-gd"
     # php-imagick, mupdf-tools, ffmpeg & gnumeric are required for file conversion and thumbnail generation: https://fossil.kd2.org/paheko/wiki?name=Configuration/Thumbnails


### PR DESCRIPTION
## Problem

- https://forum.yunohost.org/t/paheko-dompdf-logicexception-you-need-to-install-the-php-gd-extension-to-be-able-to-use-this-extension/41126/2

## Solution

- add missing dep

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
